### PR TITLE
Make CircuitBreaker timeout customizable

### DIFF
--- a/src/ServiceControl.Plugin.Nsb5.Heartbeat/ServiceControlBackend.cs
+++ b/src/ServiceControl.Plugin.Nsb5.Heartbeat/ServiceControlBackend.cs
@@ -28,7 +28,7 @@
             VerifyIfServiceControlQueueExists();
 
             circuitBreaker =
-            new RepeatedFailuresOverTimeCircuitBreaker("ServiceControlConnectivity", TimeSpan.FromMinutes(2),
+            new RepeatedFailuresOverTimeCircuitBreaker("ServiceControlConnectivity", GetCircuitBreakerTimeout(),
                 ex =>
                     criticalError.Raise(
                         "This endpoint is repeatedly unable to contact the ServiceControl backend to report endpoint information. You have the ServiceControl plugins installed in your endpoint. However, please ensure that the Particular ServiceControl service is installed on this machine, " +
@@ -149,6 +149,19 @@
                                       "\r\n Additional details: {0}";
                 criticalError.Raise(errMsg, ex);
             }
+        }
+
+        TimeSpan GetCircuitBreakerTimeout()
+        {
+            var circuitBreakerTimeoutSeconds = ConfigurationManager.AppSettings[@"ServiceControl/Heartbeat/CircuitBreakerTimeoutSeconds"];
+            if (!String.IsNullOrEmpty(circuitBreakerTimeoutSeconds))
+            {
+                int timeout;
+                if (int.TryParse(circuitBreakerTimeoutSeconds, out timeout) && timeout > 0)
+                    return TimeSpan.FromSeconds(timeout);
+            }
+
+            return TimeSpan.FromMinutes(2);
         }
 
         JsonMessageSerializer serializer;


### PR DESCRIPTION
When using SQL transport, ServiceControl database is hosted on dedicated SQL server. When something happens (network issues, planned upgrades etc.) all services are stopped in 2 minutes because of CircuitBreaker in Heartbeat plugin. We want to increase this timeout. With this patch it can be customized using optional app.config key (default value remains to be 2 minutes).
 
```
<appSettings>
    <add key="ServiceControl/Heartbeat/CircuitBreakerTimeoutSeconds" value="600" />
</appSettings>
```
