### PR TITLE
Do not shut down endpoint when ServiceControl unavailable

### DIFF
--- a/src/ServiceControl.Plugin.Nsb5.Heartbeat.AcceptanceTests/When_service_control_queue_unavailable_at_startup.cs
+++ b/src/ServiceControl.Plugin.Nsb5.Heartbeat.AcceptanceTests/When_service_control_queue_unavailable_at_startup.cs
@@ -1,35 +1,26 @@
 ﻿namespace ServiceControl.Plugin.Nsb5.Heartbeat.AcceptanceTests
 {
-    using System;
     using System.Configuration;
-    using System.Messaging;
     using NServiceBus;
     using NServiceBus.AcceptanceTesting;
-    using NServiceBus.AcceptanceTesting.Support;
     using NUnit.Framework;
 
     public class When_service_control_queue_unavailable_at_startup
     {
         [Test]
-        public void Should_honor_configured_value()
+        public void Should_not_fail_the_endpoint()
         {
             var context = new Context();
 
-            var exception = Assert.Throws<AggregateException>(() =>
-                Scenario.Define(context).WithEndpoint<EndpointWithMissingSCQueue>(b => b
-                    .CustomConfig(busConfig => busConfig
-                        .DefineCriticalErrorAction((s, e) =>
-                        {
-                            context.CriticalExceptionReceived = true;
-                        })))
-                    .AllowExceptions()
-                    .Run());
+            TestDelegate action = () => Scenario.Define(context).WithEndpoint<EndpointWithMissingSCQueue>(b => b
+                .CustomConfig(busConfig => busConfig
+                    .DefineCriticalErrorAction((s, e) =>
+                    {
+                        context.CriticalExceptionReceived = true;
+                    })))
+                .Run();
 
-            // we currently can't test for the InvalidOperationException thrown by the ServiceControlBackend
-            // class since that gets cut away in the EndpointRunner.
-            Assert.IsInstanceOf<ScenarioException>(exception.InnerException);
-            Assert.AreEqual("Endpoint EndpointWithMissingSCQueue failed to initialize", exception.InnerException.Message);
-            Assert.IsInstanceOf<MessageQueueException>(exception.InnerException.InnerException);
+            Assert.DoesNotThrow(action);
             Assert.IsFalse(context.CriticalExceptionReceived);
         }
 

--- a/src/ServiceControl.Plugin.Nsb5.Heartbeat.Sample/UseJsonSerializer.cs
+++ b/src/ServiceControl.Plugin.Nsb5.Heartbeat.Sample/UseJsonSerializer.cs
@@ -4,7 +4,6 @@
 
     class UseJsonSerializer : INeedInitialization
     {
-
         public void Customize(BusConfiguration builder)
         {
             builder.UseSerialization<JsonSerializer>();

--- a/src/ServiceControl.Plugin.Nsb5.Heartbeat/Heartbeats.cs
+++ b/src/ServiceControl.Plugin.Nsb5.Heartbeat/Heartbeats.cs
@@ -33,7 +33,6 @@
             }
             
             backend = new ServiceControlBackend(SendMessages, Configure);
-            backend.VerifyIfServiceControlQueueExists();
             heartbeatInterval = TimeSpan.FromSeconds(10); // Default interval
             var interval = ConfigurationManager.AppSettings[@"Heartbeat/Interval"];
             
@@ -87,7 +86,15 @@
                 Host = hostInfo.DisplayName,
                 HostId = hostInfo.HostId
             };
-            backend.Send(heartBeat, ttlTimeSpan);
+
+            try
+            {
+                backend.Send(heartBeat, ttlTimeSpan);
+            }
+            catch (Exception ex)
+            {
+                logger.Warn("Unable to send heartbeat to ServiceControl:", ex);
+            }
         }
 
         ServiceControlBackend backend;

--- a/src/ServiceControl.Plugin.Nsb5.Heartbeat/Heartbeats.cs
+++ b/src/ServiceControl.Plugin.Nsb5.Heartbeat/Heartbeats.cs
@@ -143,16 +143,9 @@
 
             public void Dispose()
             {
-                try
+                if (cancellationTokenSource != null)
                 {
-                    if (cancellationTokenSource != null)
-                    {
-                        cancellationTokenSource.Dispose();
-                    }
-                }
-                catch (Exception)
-                {
-                    // ignored
+                    cancellationTokenSource.Dispose();
                 }
             }
 

--- a/src/ServiceControl.Plugin.Nsb5.Heartbeat/Heartbeats.cs
+++ b/src/ServiceControl.Plugin.Nsb5.Heartbeat/Heartbeats.cs
@@ -16,10 +16,7 @@
     {
         public ISendMessages SendMessages { get; set; }
         public Configure Configure { get; set; }
-
         public UnicastBus UnicastBus { get; set; }
-
-        public CriticalError CriticalError { get; set; }
 
         static ILog logger = LogManager.GetLogger(typeof(Heartbeats));
         
@@ -35,7 +32,7 @@
                 return;
             }
             
-            backend = new ServiceControlBackend(SendMessages, Configure, CriticalError);
+            backend = new ServiceControlBackend(SendMessages, Configure);
             backend.VerifyIfServiceControlQueueExists();
             heartbeatInterval = TimeSpan.FromSeconds(10); // Default interval
             var interval = ConfigurationManager.AppSettings[@"Heartbeat/Interval"];


### PR DESCRIPTION
Currently the presence of the ServiceControl queue is checked at endpoint startup time. If the queue isn't available for some reasons (network issues, server maintenance, ...) the endpoint throws an exception and won't start. Also a circuit breaker tracks failing heartbeats (due to the same reasons as above) and shuts down the endpoint after some time.

We think it's not necessary to shutdown the endpoint when non-mission-ciritical components have temporary issues. Also, ServicePulse will show you the endpoint as unavailable when the heartbeats fail, so there should be sufficent notifications to devs/ops to check the endpoint and it's configuration.

Note:
* Will no longer support Send-Only clients because of technical reasons.