### PR TITLE
Allow heartbeats to be sent to multiple ServiceControl instances

### DIFF
--- a/src/ServiceControl.Plugin.Nsb5.Heartbeat.Sample/App.config
+++ b/src/ServiceControl.Plugin.Nsb5.Heartbeat.Sample/App.config
@@ -5,8 +5,8 @@
     <section name="AuditConfig" type="NServiceBus.Config.AuditConfig, NServiceBus.Core" />
     <section name="UnicastBusConfig" type="NServiceBus.Config.UnicastBusConfig, NServiceBus.Core" />
   </configSections>
-  <MessageForwardingInCaseOfFaultConfig ErrorQueue="sdworx.test.error" />
-  <AuditConfig QueueName="sdworx.test.audit" />
+  <MessageForwardingInCaseOfFaultConfig ErrorQueue="error" />
+  <AuditConfig QueueName="audit" />
   <startup>
     <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
   </startup>

--- a/src/ServiceControl.Plugin.Nsb5.Heartbeat.Sample/App.config
+++ b/src/ServiceControl.Plugin.Nsb5.Heartbeat.Sample/App.config
@@ -5,8 +5,8 @@
     <section name="AuditConfig" type="NServiceBus.Config.AuditConfig, NServiceBus.Core" />
     <section name="UnicastBusConfig" type="NServiceBus.Config.UnicastBusConfig, NServiceBus.Core" />
   </configSections>
-  <MessageForwardingInCaseOfFaultConfig ErrorQueue="error" />
-  <AuditConfig QueueName="audit" />
+  <MessageForwardingInCaseOfFaultConfig ErrorQueue="sdworx.test.error" />
+  <AuditConfig QueueName="sdworx.test.audit" />
   <startup>
     <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
   </startup>
@@ -14,7 +14,9 @@
     <MessageEndpointMappings />
   </UnicastBusConfig>
   <appSettings>
+    <add key="ServiceControl/Queue" value="particular.test.servicecontrol;particular.servicecontrol" />
     <add key="Heartbeat/TTL" value="00:02:00"/>
+    <add key="Heartbeat/Interval" value="00:00:30"/>
   </appSettings>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">

--- a/src/ServiceControl.Plugin.Nsb5.Heartbeat.sln.DotSettings
+++ b/src/ServiceControl.Plugin.Nsb5.Heartbeat.sln.DotSettings
@@ -171,7 +171,7 @@
             &lt;HasAttribute Name="System.Runtime.InteropServices.ComImport" /&gt;&#xD;
           &lt;/Or&gt;&#xD;
         &lt;/And&gt;&#xD;
-        &lt;HasAttribute Name="System.Runtime.InteropServices.StructLayoutAttribute" /&gt;&#xD;
+        &lt;Kind Is="Struct" /&gt;&#xD;
       &lt;/Or&gt;&#xD;
     &lt;/TypePattern.Match&gt;&#xD;
   &lt;/TypePattern&gt;&#xD;
@@ -197,7 +197,7 @@
       &lt;/Entry.Match&gt;&#xD;
     &lt;/Entry&gt;&#xD;
     &lt;Entry DisplayName="All other members" /&gt;&#xD;
-    &lt;Entry DisplayName="Test Methods" Priority="100"&gt;&#xD;
+    &lt;Entry Priority="100" DisplayName="Test Methods"&gt;&#xD;
       &lt;Entry.Match&gt;&#xD;
         &lt;And&gt;&#xD;
           &lt;Kind Is="Method" /&gt;&#xD;
@@ -210,7 +210,7 @@
     &lt;/Entry&gt;&#xD;
   &lt;/TypePattern&gt;&#xD;
   &lt;TypePattern DisplayName="Default Pattern"&gt;&#xD;
-    &lt;Entry DisplayName="Public Delegates" Priority="100"&gt;&#xD;
+    &lt;Entry Priority="100" DisplayName="Public Delegates"&gt;&#xD;
       &lt;Entry.Match&gt;&#xD;
         &lt;And&gt;&#xD;
           &lt;Access Is="Public" /&gt;&#xD;
@@ -221,7 +221,7 @@
         &lt;Name /&gt;&#xD;
       &lt;/Entry.SortBy&gt;&#xD;
     &lt;/Entry&gt;&#xD;
-    &lt;Entry DisplayName="Public Enums" Priority="100"&gt;&#xD;
+    &lt;Entry Priority="100" DisplayName="Public Enums"&gt;&#xD;
       &lt;Entry.Match&gt;&#xD;
         &lt;And&gt;&#xD;
           &lt;Access Is="Public" /&gt;&#xD;
@@ -262,7 +262,7 @@
         &lt;/Or&gt;&#xD;
       &lt;/Entry.Match&gt;&#xD;
     &lt;/Entry&gt;&#xD;
-    &lt;Entry DisplayName="Interface Implementations" Priority="100"&gt;&#xD;
+    &lt;Entry Priority="100" DisplayName="Interface Implementations"&gt;&#xD;
       &lt;Entry.Match&gt;&#xD;
         &lt;And&gt;&#xD;
           &lt;Kind Is="Member" /&gt;&#xD;
@@ -591,6 +591,7 @@ II.2.12 &lt;HandlesEvent /&gt;&#xD;
 	<s:String x:Key="/Default/CodeStyle/Naming/XamlNaming/UserRules/=XAML_005FRESOURCE/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpFileLayoutPatternsUpgrade/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EAddAccessorOwnerDeclarationBracesMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EAlwaysTreatStructAsNotReorderableMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateThisQualifierSettings/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002EJavaScript_002ECodeStyle_002ESettingsUpgrade_002EJsCodeFormatterSettingsUpgrader/@EntryIndexedValue">True</s:Boolean>

--- a/src/ServiceControl.Plugin.Nsb5.Heartbeat/Heartbeats.cs
+++ b/src/ServiceControl.Plugin.Nsb5.Heartbeat/Heartbeats.cs
@@ -41,9 +41,16 @@
                 endpointName = configure.Settings.EndpointName();
 
                 var interval = ConfigurationManager.AppSettings[@"Heartbeat/Interval"];
-                if (!String.IsNullOrEmpty(interval))
+                if (!String.IsNullOrWhiteSpace(interval))
                 {
-                    heartbeatInterval = TimeSpan.Parse(interval);
+                    if (TimeSpan.TryParse(interval, out heartbeatInterval))
+                    {
+                        Logger.InfoFormat("Heartbeat/Interval set to {0}",heartbeatInterval);
+                    }
+                    else
+                    {
+                        Logger.Warn("Invalid Heartbeat/Interval specified in AppSettings. Reverted to default Interval (10 seconds)");
+                    }
                 }
 
                 ttlTimeSpan = TimeSpan.FromTicks(heartbeatInterval.Ticks * 4); // Default ttl


### PR DESCRIPTION
Necessary changes to support sending heartbeats to multiple ServiceControl instances.

See issue 13 (https://github.com/Particular/ServiceControl.Plugin.Nsb5.Heartbeat/issues/13)