### PR TITLE
Graceful shutdown

### DIFF
--- a/src/ServiceControl.Plugin.Nsb5.Heartbeat/Heartbeats.cs
+++ b/src/ServiceControl.Plugin.Nsb5.Heartbeat/Heartbeats.cs
@@ -121,6 +121,10 @@
             {
                 backend.Send(heartBeat, ttlTimeSpan);
             }
+            catch (ObjectDisposedException ex)
+            {
+                Logger.Debug("Ignoring object disposed. Likely means we are shutting down:", ex);
+            }
             catch (Exception ex)
             {
                 Logger.Warn("Unable to send heartbeat to ServiceControl:", ex);

--- a/src/ServiceControl.Plugin.Nsb5.Heartbeat/Heartbeats.cs
+++ b/src/ServiceControl.Plugin.Nsb5.Heartbeat/Heartbeats.cs
@@ -14,6 +14,7 @@
 
     class Heartbeats : IWantToRunWhenConfigurationIsComplete, IDisposable
     {
+        private const int MillisecondsToWaitForShutdown = 500;
         static ILog Logger = LogManager.GetLogger(typeof(Heartbeats));
 
         public Heartbeats(ISendMessages sendMessages, Configure configure, UnicastBus unicastBus)
@@ -52,7 +53,7 @@
                 using (var manualResetEvent = new ManualResetEvent(false))
                 {
                     heartbeatTimer.Dispose(manualResetEvent);
-                    manualResetEvent.WaitOne();
+                    manualResetEvent.WaitOne(MillisecondsToWaitForShutdown);
                 }
             }
 

--- a/src/ServiceControl.Plugin.Nsb5.Heartbeat/Heartbeats.cs
+++ b/src/ServiceControl.Plugin.Nsb5.Heartbeat/Heartbeats.cs
@@ -49,7 +49,11 @@
         {
             if (heartbeatTimer != null)
             {
-                heartbeatTimer.Dispose();
+                using (var manualResetEvent = new ManualResetEvent(false))
+                {
+                    heartbeatTimer.Dispose(manualResetEvent);
+                    manualResetEvent.WaitOne();
+                }
             }
 
             if (cancellationTokenSource != null)


### PR DESCRIPTION
Connects to #17 

I looked at trying to finder a better abstraction to shut down the heartbeats plugin but couldn't find one that would work for all cases. Catching the exception and logging to debug seems like the best option at the moment. This allows us to detect when this exception has been thrown without polluting log files under normal operation.